### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/.circleci/orbs/orb-fsa/@orb.yml
+++ b/.circleci/orbs/orb-fsa/@orb.yml
@@ -1,5 +1,8 @@
 version: 2.1
-description: "The orb integrates WhiteSource Unified Agent, a tool which extracts descriptive information from your open source libraries located on your file system. For more information: https://whitesource.atlassian.net/wiki/spaces/WD/pages/33718339/Unified+Agent"
+description: "WhiteSource Unified Agent is a tool which extracts descriptive information from your open source libraries located on your file system."
+display:
+  home_url: https://whitesource.atlassian.net/wiki/spaces/WD/pages/33718339/Unified+Agent
+  source_url: https://github.com/whitesource/whitesource_orb
 
 executors:
   java:


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.